### PR TITLE
session fix

### DIFF
--- a/lib/jwt_credentials.rb
+++ b/lib/jwt_credentials.rb
@@ -20,9 +20,6 @@ module JWTCredentials
   end
 
   def apply_credentials
-    if current_user
-      session['user'] = current_user
-    end
     RequestStore.store[:x_authorisation] = session['user']
   end
 
@@ -50,11 +47,7 @@ module JWTCredentials
         render body: nil, status: :unauthorized
       end
     else
-      if current_user
-        session['user'] = current_user
-      else
-        build_user_session("email" => 'guest', "groups" => ['world'])
-      end
+      build_user_session("email" => 'guest', "groups" => ['world'])
     end
   end  
 end


### PR DESCRIPTION
I was finding that when a JWT was not processed, the session['user']
set to current_user, which might itself return session['user'] from a
previous JWT. If the session contained an openstruct, serializing it
would result in { "table" => { "email" => "...", "groups" => [...] }}.
Each time this gets converted to an OpenStruct, it gains another level
of nesting under "table".
So. Use a version of OpenStruct that doesn't nest its fields under
"table" when serialized.
Also, clear the session at the start of check_credentials
so that sessions from JWTs read once won't be reused in subsequent requests.